### PR TITLE
Add ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+
+before_script:
+- sudo add-apt-repository ppa:vala-team/ppa -y
+- sudo apt-get update -qq
+- sudo apt-get install -qq gnome-common libglib2.0-dev libgtk-3-dev
+- sudo apt-get install -qq libsqlite3-dev libvala-0.22-dev valac-0.22 gobject-introspection
+- sudo apt-get install -qq libwebkitgtk-3.0-dev libparted-dev libgee-dev
+- ./autogen.sh
+- ./configure
+
+script: make

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# BlankOn Linux Installer
+
+![build result](https://api.travis-ci.org/blankon/blankon-installer.svg)


### PR DESCRIPTION
`.travis.yml` is needed for attempting ci build on travis-ci.org. The current settings only check the `make` exit code.

The build status is presented on `README.md`.
