### PR TITLE
Preserve extended attributes and permissions

### DIFF
--- a/scripts/b-i-copy-fs
+++ b/scripts/b-i-copy-fs
@@ -4,6 +4,6 @@ set -e
 
 mkdir /rofs
 mount -o loop /lib/live/mount/medium/live/filesystem.squashfs /rofs
-rsync -av --progress /rofs/* /target > /tmp/b-i-copy-fs-progress
+rsync -aAXv --progress /rofs/* /target > /tmp/b-i-copy-fs-progress
 cp -a /usr/lib/locale/locale-archive /target/usr/lib/locale/
 umount /rofs


### PR DESCRIPTION
Without this flags, the files are copied without preserving extended attributes and permissions. One example would be `ping` that would lose `cap_net_raw+ep` capabilities, rendering normal user not be able to ping anywhere.
