### PR TITLE
Fix fstab generation and UUID inclusion

### DIFF
--- a/scripts/b-i-setup-fs
+++ b/scripts/b-i-setup-fs
@@ -193,7 +193,7 @@ fi
 for i in `cat $ROOTFS/tmp/swaps`;do
     mkswap $i
     UUID=`lsblk -no UUID $i`
-    echo "$UUID    none    swap    sw  0   0" >> $ROOTFS/target/etc/fstab
+    echo "UUID=$UUID    none    swap    sw  0   0" >> $ROOTFS/target/etc/fstab
 done
 
 

--- a/scripts/b-i-setup-fs
+++ b/scripts/b-i-setup-fs
@@ -50,7 +50,7 @@ then
   touch $ROOTFS/target/etc/crypttab
   echo "root /dev/lvm/root none luks,retry=1" > $ROOTFS/target/etc/crypttab
   touch $ROOTFS/target/etc/fstab
-  echo "/dev/mapper/root ext4 relatime,errors=remount-ro 0 1" >> $ROOTFS/target/etc/fstab
+  echo "/dev/mapper/root / ext4 relatime,errors=remount-ro 0 1" >> $ROOTFS/target/etc/fstab
   echo "/dev/mapper/lvm-swap    none    swap    sw  0   0" >> $ROOTFS/target/etc/fstab
   echo "$BOOT /boot vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 2" >> $ROOTFS/target/etc/fstab
   

--- a/scripts/b-i-setup-fs
+++ b/scripts/b-i-setup-fs
@@ -192,7 +192,8 @@ fi
 
 for i in `cat $ROOTFS/tmp/swaps`;do
     mkswap $i
-    echo "$i    none    swap    sw  0   0" >> $ROOTFS/target/etc/fstab
+    UUID=`lsblk -no UUID $i`
+    echo "$UUID    none    swap    sw  0   0" >> $ROOTFS/target/etc/fstab
 done
 
 

--- a/src/installer.vala
+++ b/src/installer.vala
@@ -551,12 +551,20 @@ public class Installation : GLib.Object {
             do_simple_command_with_args (c, Step.MOUNTHOME, "mounting_home_filesystem ", "Unable to mount home filesystem");
         
             // write fstab file at tmp, will be copied to /target/etc/fstab by b-i-setup-fs script
-            var content = "UUID=" + backtick("/bin/lsblk -no UUID " + partition_path) + " / ext4 defaults 1 2";
-            Utils.write_simple_file ("/tmp/fstab", content);
-            content = "UUID=" + backtick("/bin/lsblk -no UUID " + home) + " /home ext4 defaults 1 2";
+            var root_partition = backtick("/bin/lsblk -no UUID " + partition_path);
+            var home_partition = backtick("/bin/lsblk -no UUID " + home);
+
+            var content = "UUID=" + root_partition + " / ext4 defaults 1 2\n";
+               content += "UUID=" + home_partition + " /home ext4 defaults 1 2\n";
             Utils.write_simple_file ("/tmp/fstab", content);
 
         } else {
+            // write fstab file at tmp, will be copied to /target/etc/fstab by b-i-setup-fs script
+            var root_partition = backtick("/bin/lsblk -no UUID " + partition_path);
+
+            var content = "UUID=" + root_partition + " / ext4 defaults 1 2\n";
+            Utils.write_simple_file ("/tmp/fstab", content);
+
             last_step = Step.MOUNTHOME;
             do_next_job ();
         }
@@ -678,7 +686,7 @@ public class Installation : GLib.Object {
         int exitCode;
         string std_out;
         Process.spawn_command_line_sync(command, out std_out, null, out exitCode);
-        return std_out;
+        return std_out.replace("/n", "");
       }
       catch (GLib.Error e){
         Log.instance().log ("Error running: " + e.message);

--- a/src/installer.vala
+++ b/src/installer.vala
@@ -551,9 +551,9 @@ public class Installation : GLib.Object {
             do_simple_command_with_args (c, Step.MOUNTHOME, "mounting_home_filesystem ", "Unable to mount home filesystem");
         
             // write fstab file at tmp, will be copied to /target/etc/fstab by b-i-setup-fs script
-            var content = partition_path + " / ext4 defaults 1 2";
+            var content = "UUID=" + backtick("/bin/lsblk -no UUID " + partition_path) + " / ext4 defaults 1 2";
             Utils.write_simple_file ("/tmp/fstab", content);
-            content = home + " /home ext4 defaults 1 2";
+            content = "UUID=" + backtick("/bin/lsblk -no UUID " + home) + " /home ext4 defaults 1 2";
             Utils.write_simple_file ("/tmp/fstab", content);
 
         } else {
@@ -670,6 +670,20 @@ public class Installation : GLib.Object {
 
         return result;
 
+    }
+
+    public string backtick (string command)
+    {
+      try {
+        int exitCode;
+        string std_out;
+        Process.spawn_command_line_sync(command, out std_out, null, out exitCode);
+        return std_out;
+      }
+      catch (GLib.Error e){
+        Log.instance().log ("Error running: " + e.message);
+        return "";
+      }
     }
 
     int run (string[] command) {


### PR DESCRIPTION
WARNING: This contains PR#85 as well.

This fixes a flaw when generating fstab, in which the `/` mount point was not there. Subsequently, this flaw makes crypsetup hook during initramfs update to fail to detect the root mountpoint so it then disables cryptsetup feature, rendering the encrypted installation to brick.
